### PR TITLE
chore: Fix ruby 3.3 buffering issue

### DIFF
--- a/lib/net/ssh/buffered_io.rb
+++ b/lib/net/ssh/buffered_io.rb
@@ -61,7 +61,7 @@ module Net
       # if no data was available to be read.
       def fill(n = 8192)
         input.consume!
-        data = recv(n)
+        data = recv(n) || ""
         debug { "read #{data.length} bytes" }
         input.append(data)
         return data.length


### PR DESCRIPTION
Fix issue with ruby 3.3, the change was made upstream in this PR: https://github.com/net-ssh/net-ssh/pull/928

Bringing this change to our fork while @flux-benj works on merging changes upstream to `net-ssh`